### PR TITLE
Fix cpu_features usage. Update compatibility with new GraphBLAS version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,11 +163,12 @@ if ( DEFINED GBAVX512F )
 endif ( )
 
 #-------------------------------------------------------------------------------
-# RISC-V 
+# RISC-V
 #-------------------------------------------------------------------------------
 
 if ( DEFINED GBRISCV64 )
     if ( GBRISCV64 )
+    # default: this is detected automatically, but can be set here also
         set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRISCV64=1 " )
     else ( )
         set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRISCV64=0 " )
@@ -176,6 +177,7 @@ endif ( )
 
 if ( DEFINED GBRVV )
     if ( GBRVV )
+    # default: this is detected automatically, but can be set here also
         set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRVV=1 " )
     else ( )
         set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRVV=0 " )

--- a/FactoryKernels/GB_AxB__plus_times_fp32.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp32.c
@@ -7,14 +7,6 @@
 
 //------------------------------------------------------------------------------
 
-#if __riscv
-#include <riscv_vector.h>
-#define VSETVL(x) __riscv_vsetvl_e32m8(x)
-#define VLE(x,y) __riscv_vle32_v_f32m8(x, y)
-#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f32m8(x, y, z, w)
-#define VSE(x,y,z) __riscv_vse32_v_f32m8(x, y, z)
-#define VECTORTYPE vfloat32m8_t
-#endif
 #include "GB_control.h"
 #if defined (GxB_NO_FP32)
 #define GB_TYPE_ENABLED 0
@@ -302,6 +294,13 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp32)
         //---------------------------------------------------------------------
 
         #if GB_COMPILER_SUPPORTS_RVV1
+
+            #include <riscv_vector.h>
+            #define VSETVL(x) __riscv_vsetvl_e32m8(x)
+            #define VLE(x,y) __riscv_vle32_v_f32m8(x, y)
+            #define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f32m8(x, y, z, w)
+            #define VSE(x,y,z) __riscv_vse32_v_f32m8(x, y, z)
+            #define VECTORTYPE vfloat32m8_t
 
             GB_TARGET_RVV1 static inline void GB_AxB_saxpy5_unrolled_rvv
             (

--- a/FactoryKernels/GB_AxB__plus_times_fp32.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp32.c
@@ -7,7 +7,7 @@
 
 //------------------------------------------------------------------------------
 
-#ifdef GBRISCV64
+#if __riscv
 #include <riscv_vector.h>
 #define VSETVL(x) __riscv_vsetvl_e32m8(x)
 #define VLE(x,y) __riscv_vle32_v_f32m8(x, y)

--- a/FactoryKernels/GB_AxB__plus_times_fp32.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp32.c
@@ -9,6 +9,11 @@
 
 #ifdef GBRISCV64
 #include <riscv_vector.h>
+#define VSETVL(x) __riscv_vsetvl_e32m8(x)
+#define VLE(x,y) __riscv_vle32_v_f32m8(x, y)
+#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f32m8(x, y, z, w)
+#define VSE(x,y,z) __riscv_vse32_v_f32m8(x, y, z)
+#define VECTORTYPE vfloat32m8_t
 #endif
 #include "GB_control.h"
 #if defined (GxB_NO_FP32)
@@ -22,14 +27,6 @@
 #include "mxm/GB_AxB_saxpy.h"
 #include "assign/GB_bitmap_assign_methods.h"
 #include "FactoryKernels/GB_AxB__include2.h"
-
-// riscv intrinsics
-
-#define VSETVL(x) __riscv_vsetvl_e32m8(x)
-#define VLE(x,y) __riscv_vle32_v_f32m8(x, y)
-#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f32m8(x, y, z, w)
-#define VSE(x,y,z) __riscv_vse32_v_f32m8(x, y, z)
-#define VECTORTYPE vfloat32m8_t
 
 // semiring operators:
 #define GB_MULTADD(z,a,b,i,k,j) z += (a*b)

--- a/FactoryKernels/GB_AxB__plus_times_fp64.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp64.c
@@ -7,7 +7,7 @@
 
 //------------------------------------------------------------------------------
 
-#ifdef GBRISCV64
+#if __riscv
 #include <riscv_vector.h>
 #define VSETVL(x) __riscv_vsetvl_e64m8(x)
 #define VLE(x,y) __riscv_vle64_v_f64m8(x, y)
@@ -15,6 +15,7 @@
 #define VSE(x,y,z) __riscv_vse64_v_f64m8(x, y, z)
 #define VECTORTYPE vfloat64m8_t
 #endif
+#include <stdio.h>
 #include "GB_control.h"
 #if defined (GxB_NO_FP64)
 #define GB_TYPE_ENABLED 0
@@ -312,6 +313,7 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp64)
                 const int64_t *B_slice
             )
             {
+                printf("rvv\n");
                 #include "mxm/template/GB_AxB_saxpy5_lv.c"
             }
 
@@ -339,6 +341,7 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp64)
             const int64_t *B_slice
         )
         {
+            printf("van\n");
             #include "mxm/template/GB_AxB_saxpy5_unrolled.c"
         }
 

--- a/FactoryKernels/GB_AxB__plus_times_fp64.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp64.c
@@ -312,7 +312,6 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp64)
                 const int64_t *B_slice
             )
             {
-                printf("rvv\n");
                 #include "mxm/template/GB_AxB_saxpy5_lv.c"
             }
 
@@ -340,7 +339,6 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp64)
             const int64_t *B_slice
         )
         {
-            printf("van\n");
             #include "mxm/template/GB_AxB_saxpy5_unrolled.c"
         }
 

--- a/FactoryKernels/GB_AxB__plus_times_fp64.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp64.c
@@ -7,15 +7,6 @@
 
 //------------------------------------------------------------------------------
 
-#if __riscv
-#include <riscv_vector.h>
-#define VSETVL(x) __riscv_vsetvl_e64m8(x)
-#define VLE(x,y) __riscv_vle64_v_f64m8(x, y)
-#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f64m8(x, y, z, w)
-#define VSE(x,y,z) __riscv_vse64_v_f64m8(x, y, z)
-#define VECTORTYPE vfloat64m8_t
-#endif
-#include <stdio.h>
 #include "GB_control.h"
 #if defined (GxB_NO_FP64)
 #define GB_TYPE_ENABLED 0
@@ -301,7 +292,15 @@ GrB_Info GB (_Asaxpy4B__plus_times_fp64)
         //----------------------------------------------------------------------
         // saxpy5 method with RISC-V vectors
         //----------------------------------------------------------------------
+
         #if GB_COMPILER_SUPPORTS_RVV1
+
+        #include <riscv_vector.h>
+        #define VSETVL(x) __riscv_vsetvl_e64m8(x)
+        #define VLE(x,y) __riscv_vle64_v_f64m8(x, y)
+        #define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f64m8(x, y, z, w)
+        #define VSE(x,y,z) __riscv_vse64_v_f64m8(x, y, z)
+        #define VECTORTYPE vfloat64m8_t
 
             GB_TARGET_RVV1 static inline void GB_AxB_saxpy5_unrolled_rvv
             (

--- a/FactoryKernels/GB_AxB__plus_times_fp64.c
+++ b/FactoryKernels/GB_AxB__plus_times_fp64.c
@@ -9,6 +9,11 @@
 
 #ifdef GBRISCV64
 #include <riscv_vector.h>
+#define VSETVL(x) __riscv_vsetvl_e64m8(x)
+#define VLE(x,y) __riscv_vle64_v_f64m8(x, y)
+#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f64m8(x, y, z, w)
+#define VSE(x,y,z) __riscv_vse64_v_f64m8(x, y, z)
+#define VECTORTYPE vfloat64m8_t
 #endif
 #include "GB_control.h"
 #if defined (GxB_NO_FP64)
@@ -22,14 +27,6 @@
 #include "mxm/GB_AxB_saxpy.h"
 #include "assign/GB_bitmap_assign_methods.h"
 #include "FactoryKernels/GB_AxB__include2.h"
-
-// riscv intrinsics
-
-#define VSETVL(x) __riscv_vsetvl_e64m8(x)
-#define VLE(x,y) __riscv_vle64_v_f64m8(x, y)
-#define VFMACC(x,y,z,w) __riscv_vfmacc_vf_f64m8(x, y, z, w)
-#define VSE(x,y,z) __riscv_vse64_v_f64m8(x, y, z)
-#define VECTORTYPE vfloat64m8_t
 
 // semiring operators:
 #define GB_MULTADD(z,a,b,i,k,j) z += (a*b)

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -123,6 +123,28 @@ if ( DEFINED GBAVX512F )
 endif ( )
 
 #-------------------------------------------------------------------------------
+# RISC-V
+#-------------------------------------------------------------------------------
+
+if ( DEFINED GBRISCV64 )
+    if ( GBRISCV64 )
+    # default: this is detected automatically, but can be set here also
+        set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRISCV64=1 " )
+    else ( )
+        set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRISCV64=0 " )
+    endif ( )
+endif ( )
+
+if ( DEFINED GBRVV )
+    if ( GBRVV )
+    # default: this is detected automatically, but can be set here also
+        set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRVV=1 " )
+    else ( )
+        set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBRVV=0 " )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # determine build type
 #-------------------------------------------------------------------------------
 

--- a/Source/cpu/GB_cpu_features.h
+++ b/Source/cpu/GB_cpu_features.h
@@ -38,8 +38,12 @@
     #include "cpu_features_macros.h"
     #define STACK_LINE_READER_BUFFER_SIZE 1024
     #if GBX86
-    // Intel x86 (also AMD): other architectures are not exploited
+    // Intel x86 (also AMD)
     #include "cpuinfo_x86.h"
+    #endif
+    #if GBRISCV64
+    // RISC-V
+    #include "cpuinfo_riscv.h"
     #endif
 #endif
 

--- a/Source/global/GB_Global.c
+++ b/Source/global/GB_Global.c
@@ -361,20 +361,32 @@ void GB_Global_cpu_features_query (void)
     }
     #elif GBRISCV64
     {
+
         //----------------------------------------------------------------------
-        // xRISC-V architecture: see if RVV1.0 is supported
+        // RISC-V architecture: see if RVV1.0 is supported
         //----------------------------------------------------------------------
 
-        #if defined ( GBRVV )
+        #if !defined ( GBNCPUFEAT )
         {
+            // Google's cpu_features package is available: use run-time tests
+            RiscvFeatures features = GetRiscvInfo ().features ;
+            GB_Global.cpu_features_rvv_1_0 = (bool) (features.V) ;
+
+        }
+        #else
+        {
+            #if defined ( GBRVV )
+            {
                 // the build system asserts whether or not RVV1.0 is available
                 GB_Global.cpu_features_rvv_1_0 = (bool) (GBRVV) ;
-        }
+            }
             #else
             {
                 // RVV1.0 not available
                 GB_Global.cpu_features_rvv_1_0 = false ;
             }
+            #endif
+        }
         #endif
 
     }

--- a/Source/mxm/template/GB_AxB_saxpy5_lv.c
+++ b/Source/mxm/template/GB_AxB_saxpy5_lv.c
@@ -1,40 +1,70 @@
+//------------------------------------------------------------------------------
+// GB_AxB_saxpy5_lv.c: C+=A*B when C is full
+//------------------------------------------------------------------------------
+
 {
-    const int64_t m = C->vlen;
+
+    //--------------------------------------------------------------------------
+    // get C, A, and B
+    //--------------------------------------------------------------------------
+
+    const int64_t m = C->vlen;     // # of rows of C and A
     GB_Bp_DECLARE (Bp, const) ; GB_Bp_PTR (Bp, B) ;
     GB_Bh_DECLARE (Bh, const) ; GB_Bh_PTR (Bh, B) ;
     GB_Bi_DECLARE (Bi, const) ; GB_Bi_PTR (Bi, B) ;
     const bool B_iso = B->iso ;
     const GB_A_TYPE *restrict Ax = (GB_A_TYPE *)A->x;
     const GB_B_TYPE *restrict Bx = (GB_B_TYPE *)B->x;
+    // get the max number of elements that vector can store
     size_t vl = VSETVL(m);
     GB_C_TYPE *restrict Cx = (GB_C_TYPE *)C->x;
 
-#pragma omp parallel for num_threads(nthreads) schedule(dynamic, 1)
+    //--------------------------------------------------------------------------
+    // C += A*B where A is full (and not iso or pattern-only)
+    //--------------------------------------------------------------------------
+
+    #pragma omp parallel for num_threads(nthreads) schedule(dynamic, 1)
     for (int tid = 0; tid < ntasks; tid++)
     {
+        // get the task descriptor
         const int64_t jB_start = B_slice[tid];
         const int64_t jB_end = B_slice[tid + 1];
-
+        // C(:,jB_start:jB_end-1) += A * B(:,jB_start:jB_end-1)
         for (int64_t jB = jB_start; jB < jB_end; jB++)
         {
+            // get B(:,j) and C(:,j)
             const int64_t j = GBh_B (Bh, jB) ;
             GB_C_TYPE *restrict Cxj = Cx + (j * m) ;
             const int64_t pB_start = GB_IGET (Bp, jB) ;
             const int64_t pB_end   = GB_IGET (Bp, jB+1) ;
+
+            //------------------------------------------------------------------
+            // C(:,j) += A*B(:,j), on sets of vl rows of C and A at a time
+            //------------------------------------------------------------------
+
             for (int64_t i = 0; i < m && (m - i) >= vl; i += vl)
             {
+                // get C(i:i+vl,j)
                 VECTORTYPE vc = VLE(Cxj + i, vl);
                 for (int64_t pB = pB_start; pB < pB_end; pB++)
                 {
+                    // bkj = B(k,j)
                     const int64_t k = GB_IGET (Bi, pB) ;
                     GB_DECLAREB (bkj) ;
                     GB_GETB (bkj, Bx, pB, B_iso) ;
+                    // get A(i,k)
                     VECTORTYPE va = VLE(Ax + i + k * m, vl);
+                    // C(i:i+15,j) += A(i:i+15,k)*B(k,j)
                     vc = VFMACC(vc, bkj, va, vl);
                 }
-
+                // save C(i:i+15,j)
                 VSE(Cxj + i, vc, vl);
             }
+
+            //------------------------------------------------------------------
+            // lines 179-1036 from GB_AxB_saxpy5_unrolled.c
+            //------------------------------------------------------------------
+
             int64_t remaining = m % vl;
             if (remaining > 0)
             {

--- a/Source/mxm/template/GB_AxB_saxpy5_lv.c
+++ b/Source/mxm/template/GB_AxB_saxpy5_lv.c
@@ -1,8 +1,9 @@
 {
     const int64_t m = C->vlen;
-    const int64_t *restrict Bp = B->p;
-    const int64_t *restrict Bh = B->h;
-    const int64_t *restrict Bi = B->i;
+    GB_Bp_DECLARE (Bp, const) ; GB_Bp_PTR (Bp, B) ;
+    GB_Bh_DECLARE (Bh, const) ; GB_Bh_PTR (Bh, B) ;
+    GB_Bi_DECLARE (Bi, const) ; GB_Bi_PTR (Bi, B) ;
+    const bool B_iso = B->iso ;
     const GB_A_TYPE *restrict Ax = (GB_A_TYPE *)A->x;
     const GB_B_TYPE *restrict Bx = (GB_B_TYPE *)B->x;
     size_t vl = VSETVL(m);
@@ -16,17 +17,18 @@
 
         for (int64_t jB = jB_start; jB < jB_end; jB++)
         {
-            const int64_t j = GBH_B(Bh, jB);
-            GB_C_TYPE *restrict Cxj = Cx + (j * m);
-            const int64_t pB_start = Bp[jB];
-            const int64_t pB_end = Bp[jB + 1];
+            const int64_t j = GBh_B (Bh, jB) ;
+            GB_C_TYPE *restrict Cxj = Cx + (j * m) ;
+            const int64_t pB_start = GB_IGET (Bp, jB) ;
+            const int64_t pB_end   = GB_IGET (Bp, jB+1) ;
             for (int64_t i = 0; i < m && (m - i) >= vl; i += vl)
             {
                 VECTORTYPE vc = VLE(Cxj + i, vl);
                 for (int64_t pB = pB_start; pB < pB_end; pB++)
                 {
-                    const int64_t k = Bi[pB];
-                    const GB_B_TYPE bkj = Bx[pB];
+                    const int64_t k = GB_IGET (Bi, pB) ;
+                    GB_DECLAREB (bkj) ;
+                    GB_GETB (bkj, Bx, pB, B_iso) ;
                     VECTORTYPE va = VLE(Ax + i + k * m, vl);
                     vc = VFMACC(vc, bkj, va, vl);
                 }
@@ -40,8 +42,9 @@
                 VECTORTYPE vc = VLE(Cxj + i, remaining);
                 for (int64_t pB = pB_start; pB < pB_end; pB++)
                 {
-                    const int64_t k = Bi[pB];
-                    const GB_B_TYPE bkj = Bx[pB];
+                    const int64_t k = GB_IGET (Bi, pB) ;
+                    GB_DECLAREB (bkj) ;
+                    GB_GETB (bkj, Bx, pB, B_iso) ;
                     VECTORTYPE va = VLE(Ax + i + k * m, remaining);
                     vc = VFMACC(vc, bkj, va, remaining);
                 }

--- a/cpu_features/include/cpu_features_macros.h
+++ b/cpu_features/include/cpu_features_macros.h
@@ -63,6 +63,22 @@
 #define CPU_FEATURES_ARCH_PPC
 #endif
 
+#if defined(__riscv)
+#define CPU_FEATURES_ARCH_RISCV
+#endif
+
+#if defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 32
+#define CPU_FEATURES_ARCH_RISCV32
+#endif
+
+#if defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
+#define CPU_FEATURES_ARCH_RISCV64
+#endif
+
+#if defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 128
+#define CPU_FEATURES_ARCH_RISCV128
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 // Os
 ////////////////////////////////////////////////////////////////////////////////
@@ -225,6 +241,114 @@
 #define CPU_FEATURES_COMPILED_MIPS_MSA 0
 #endif  //  defined(__mips_msa)
 #endif  //  defined(CPU_FEATURES_ARCH_MIPS)
+
+#if defined(CPU_FEATURES_ARCH_RISCV)
+#if defined(__riscv_e)
+#define CPU_FEATURES_COMPILED_RISCV_E 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_E 0
+#endif
+#if defined(__riscv_i)
+#define CPU_FEATURES_COMPILED_RISCV_I 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_I 0
+#endif
+#if defined(__riscv_m)
+#define CPU_FEATURES_COMPILED_RISCV_M 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_M 0
+#endif
+#if defined(__riscv_a)
+#define CPU_FEATURES_COMPILED_RISCV_A 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_A 0
+#endif
+#if defined(__riscv_f)
+#define CPU_FEATURES_COMPILED_RISCV_F 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_F 0
+#endif
+#if defined(__riscv_d)
+#define CPU_FEATURES_COMPILED_RISCV_D 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_D 0
+#endif
+#if defined(__riscv_q)
+#define CPU_FEATURES_COMPILED_RISCV_Q 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_Q 0
+#endif
+#if defined(__riscv_c)
+#define CPU_FEATURES_COMPILED_RISCV_C 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_C 0
+#endif
+#if defined(__riscv_v)
+#define CPU_FEATURES_COMPILED_RISCV_V 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_V 0
+#endif
+#if defined(__riscv_zba)
+#define CPU_FEATURES_COMPILED_RISCV_ZBA 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZBA 0
+#endif
+#if defined(__riscv_zbb)
+#define CPU_FEATURES_COMPILED_RISCV_ZBB 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZBB 0
+#endif
+#if defined(__riscv_zbc)
+#define CPU_FEATURES_COMPILED_RISCV_ZBC 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZBC 0
+#endif
+#if defined(__riscv_zbs)
+#define CPU_FEATURES_COMPILED_RISCV_ZBS 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZBS 0
+#endif
+#if defined(__riscv_zfh)
+#define CPU_FEATURES_COMPILED_RISCV_ZFH 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZFH 0
+#endif
+#if defined(__riscv_zfhmin)
+#define CPU_FEATURES_COMPILED_RISCV_ZFHMIN 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZFHMIN 0
+#endif
+#if defined(__riscv_zknd)
+#define CPU_FEATURES_COMPILED_RISCV_ZKND 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKND 0
+#endif
+#if defined(__riscv_zkne)
+#define CPU_FEATURES_COMPILED_RISCV_ZKNE 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKNE 0
+#endif
+#if defined(__riscv_zknh)
+#define CPU_FEATURES_COMPILED_RISCV_ZKNH 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKNH 0
+#endif
+#if defined(__riscv_zksed)
+#define CPU_FEATURES_COMPILED_RISCV_ZKSED 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKSED 0
+#endif
+#if defined(__riscv_zksh)
+#define CPU_FEATURES_COMPILED_RISCV_ZKSH 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKSH 0
+#endif
+#if defined(__riscv_zkr)
+#define CPU_FEATURES_COMPILED_RISCV_ZKR 1
+#else
+#define CPU_FEATURES_COMPILED_RISCV_ZKR 0
+#endif
+#endif  //  defined(CPU_FEATURES_ARCH_RISCV)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Utils

--- a/cpu_features/include/internal/hwcaps.h
+++ b/cpu_features/include/internal/hwcaps.h
@@ -110,6 +110,18 @@ CPU_FEATURES_START_CPP_NAMESPACE
 #define ARM_HWCAP2_SHA2 (1UL << 3)
 #define ARM_HWCAP2_CRC32 (1UL << 4)
 
+// https://elixir.bootlin.com/linux/latest/source/arch/riscv/include/uapi/asm/hwcap.h
+#define RISCV_HWCAP_32 0x32
+#define RISCV_HWCAP_64 0x64
+#define RISCV_HWCAP_128 0x128
+#define RISCV_HWCAP_M (1UL << ('M' - 'A'))
+#define RISCV_HWCAP_A (1UL << ('A' - 'A'))
+#define RISCV_HWCAP_F (1UL << ('F' - 'A'))
+#define RISCV_HWCAP_D (1UL << ('D' - 'A'))
+#define RISCV_HWCAP_Q (1UL << ('Q' - 'A'))
+#define RISCV_HWCAP_C (1UL << ('C' - 'A'))
+#define RISCV_HWCAP_V (1UL << ('V' - 'A'))
+
 // http://elixir.free-electrons.com/linux/latest/source/arch/mips/include/uapi/asm/hwcap.h
 #define MIPS_HWCAP_R6 (1UL << 0)
 #define MIPS_HWCAP_MSA (1UL << 1)

--- a/cpu_features/src/utils/list_cpu_features.c
+++ b/cpu_features/src/utils/list_cpu_features.c
@@ -207,6 +207,9 @@ DEFINE_ADD_FLAGS(GetMipsFeaturesEnumValue, GetMipsFeaturesEnumName,
 #elif defined(CPU_FEATURES_ARCH_PPC)
 DEFINE_ADD_FLAGS(GetPPCFeaturesEnumValue, GetPPCFeaturesEnumName, PPCFeatures,
                  PPC_LAST_)
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+DEFINE_ADD_FLAGS(GetRiscvFeaturesEnumValue, GetRiscvFeaturesEnumName,
+                 RiscvFeatures, RISCV_LAST_)
 #endif
 
 // Prints a json string with characters escaping.
@@ -411,6 +414,12 @@ static Node* CreateTree() {
   AddMapEntry(root, "instruction", CreateString(strings.type.platform));
   AddMapEntry(root, "microarchitecture",
               CreateString(strings.type.base_platform));
+  AddFlags(root, &info.features);
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+  const RiscvInfo info = GetRiscvInfo();
+  AddMapEntry(root, "arch", CreateString("risc-v"));
+  AddMapEntry(root, "vendor", CreateString(info.vendor));
+  AddMapEntry(root, "microarchitecture", CreateString(info.uarch));
   AddFlags(root, &info.features);
 #endif
   return root;


### PR DESCRIPTION
- Now cpu_features really work on RISC-V arch
- Update saxpy5 long vectors. Make it compatibе with GraphBLAS 10.0.0
- Add comments in saxpy5 long vectors